### PR TITLE
Companies and speakers without participations now appear in searchBar

### DIFF
--- a/backend/src/mongodb/company.go
+++ b/backend/src/mongodb/company.go
@@ -132,8 +132,10 @@ func (c *CompaniesType) GetCompanies(compOptions GetCompaniesOptions) ([]*models
 		elemMatch["member"] = compOptions.MemberID
 	}
 
-	filter["participations"] = bson.M{
-		"$elemMatch": elemMatch,
+	if compOptions.EventID != nil || compOptions.IsPartner != nil || compOptions.MemberID != nil {
+		filter["participations"] = bson.M{
+			"$elemMatch": elemMatch,
+		}
 	}
 
 	if compOptions.Name != nil {

--- a/backend/src/mongodb/speaker.go
+++ b/backend/src/mongodb/speaker.go
@@ -175,8 +175,11 @@ func (s *SpeakersType) GetSpeakers(speakOptions GetSpeakersOptions) ([]*models.S
 	if speakOptions.MemberID != nil {
 		elemMatch["member"] = speakOptions.MemberID
 	}
-	filter["participations"] = bson.M{
-		"$elemMatch": elemMatch,
+
+	if speakOptions.EventID != nil || speakOptions.MemberID != nil {
+		filter["participations"] = bson.M{
+			"$elemMatch": elemMatch,
+		}
 	}
 
 	if speakOptions.Name != nil {

--- a/frontend/lib/components/SearchResultWidget.dart
+++ b/frontend/lib/components/SearchResultWidget.dart
@@ -39,11 +39,26 @@ class SearchResultWidget extends StatelessWidget {
         },
         child: Center(
           child: ListTile(
-            leading: CircleAvatar(
-              foregroundImage: NetworkImage(getImageURL()),
-              backgroundImage: AssetImage(
-                'assets/noImage.png',
+            leading: Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white,
               ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(300.0),
+                child: Image.network(
+                  getImageURL(),
+                  fit: BoxFit.cover,
+                  errorBuilder: (BuildContext context, Object exception,
+                    StackTrace? stackTrace) {
+                      return Image.asset(
+                        'assets/noImage.png'
+                      );
+                  }
+                ),
+              )
             ),
             title: Text(getName()),
           ),

--- a/frontend/lib/routes/company/CompanyScreen.dart
+++ b/frontend/lib/routes/company/CompanyScreen.dart
@@ -158,6 +158,8 @@ class _CompanyScreenState extends State<CompanyScreen>
                       Container(
                         child: Center(child: Text('Work in progress :)')),
                       ),
+                      widget.company.participations!.isEmpty ?
+                      Center(child: Text('No participations yet')):
                       ParticipationList(
                         company: widget.company,
                         onParticipationChanged:
@@ -180,6 +182,8 @@ class _CompanyScreenState extends State<CompanyScreen>
                                   partner: false,
                                 )),
                       ),
+                      widget.company.participations!.isEmpty ?
+                      Center(child: Text('No communications yet')):
                       CommunicationsList(
                           participations: widget.company.participations ?? [],
                           small: small),

--- a/frontend/lib/routes/speaker/SpeakerScreen.dart
+++ b/frontend/lib/routes/speaker/SpeakerScreen.dart
@@ -104,6 +104,8 @@ class _SpeakerScreenState extends State<SpeakerScreen>
                   Container(
                     child: Center(child: Text('Work in progress :)')),
                   ),
+                  widget.speaker.participations!.isEmpty ?
+                  Center(child: Text('No participations yet')):
                   ParticipationList(
                     speaker: widget.speaker,
                     onParticipationChanged: (Map<String, dynamic> body) async {
@@ -122,6 +124,8 @@ class _SpeakerScreenState extends State<SpeakerScreen>
                         fs: _speakerService.removeParticipation(
                             id: widget.speaker.id)),
                   ),
+                  widget.speaker.participations!.isEmpty ?
+                  Center(child: Text('No communications yet')):
                   CommunicationsList(
                       participations: widget.speaker.participations ?? [],
                       small: small),


### PR DESCRIPTION
- Companies and speakers without participations now appear in searchBar.
- Minor fix in searchBar result images.
- Added placeholder text in participation and communication tabs for when there are none.