### PR TITLE
Fix: Allow select/copy banners titles

### DIFF
--- a/frontend/lib/routes/company/banner/CompanyBanner.dart
+++ b/frontend/lib/routes/company/banner/CompanyBanner.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:frontend/components/blurryDialog.dart';
 import 'package:frontend/components/deckTheme.dart';
 import 'package:frontend/components/eventNotifier.dart';
@@ -127,12 +128,23 @@ class CompanyBanner extends StatelessWidget {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            SelectableText(
-                              company.name,
-                              style: TextStyle(
-                                overflow: TextOverflow.ellipsis,
-                              ).merge(Theme.of(context).textTheme.headline5),
-                            ),
+                            Row(
+                              children: [
+                                SelectableText(
+                                  company.name,
+                                  style: TextStyle(
+                                    overflow: TextOverflow.ellipsis,
+                                  ).merge(Theme.of(context).textTheme.headline5),
+                                ),
+                                IconButton(
+                                  onPressed: () => Clipboard.setData(ClipboardData(text: company.name)).then((_) => ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text('Company name copied to clipboard'))
+                                  )),
+                                  icon: Icon(Icons.copy),
+                                  iconSize: 18,
+                                  color: Theme.of(context).colorScheme.secondary
+                                ),
+                            ]),
                             if (isLatestEvent && hasParticipation)
                               CompanyStatusDropdownButton(
                                 companyStatus: companyStatus,

--- a/frontend/lib/routes/company/banner/CompanyBanner.dart
+++ b/frontend/lib/routes/company/banner/CompanyBanner.dart
@@ -127,10 +127,11 @@ class CompanyBanner extends StatelessWidget {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
+                            SelectableText(
                               company.name,
-                              style: Theme.of(context).textTheme.headline5,
-                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                overflow: TextOverflow.ellipsis,
+                              ).merge(Theme.of(context).textTheme.headline5),
                             ),
                             if (isLatestEvent && hasParticipation)
                               CompanyStatusDropdownButton(

--- a/frontend/lib/routes/meeting/MeetingBanner.dart
+++ b/frontend/lib/routes/meeting/MeetingBanner.dart
@@ -168,10 +168,11 @@ class MeetingBanner extends StatelessWidget {
                           children: [
                             Container(
                                 margin: EdgeInsets.only(bottom: 25),
-                                child: Text(
+                                child: SelectableText(
                                   meeting.title.toUpperCase(),
-                                  style: TextStyle(fontSize: _titleFontSize),
-                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    fontSize: _titleFontSize,
+                                    overflow: TextOverflow.ellipsis),
                                 )),
                             Padding(
                                 padding: EdgeInsets.symmetric(

--- a/frontend/lib/routes/session/SessionBanner.dart
+++ b/frontend/lib/routes/session/SessionBanner.dart
@@ -156,7 +156,7 @@ class _SessionBannerState extends State<SessionBanner> {
             Text(kind,
                 style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
             SizedBox(height: 10),
-            Text(
+            SelectableText(
                 widget.session.title.substring(
                         0,
                         widget.session.title.length < 30

--- a/frontend/lib/routes/speaker/banner/SpeakerBanner.dart
+++ b/frontend/lib/routes/speaker/banner/SpeakerBanner.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:frontend/components/blurryDialog.dart';
 import 'package:frontend/components/deckTheme.dart';
 import 'package:frontend/components/eventNotifier.dart';
@@ -126,12 +127,23 @@ class SpeakerBanner extends StatelessWidget {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            SelectableText(
-                              speaker.name,
-                              style: TextStyle(
-                                overflow: TextOverflow.ellipsis,
-                              ).merge(Theme.of(context).textTheme.headline5),
-                            ),
+                            Row(
+                              children: [
+                                SelectableText(
+                                  speaker.name,
+                                  style: TextStyle(
+                                    overflow: TextOverflow.ellipsis,
+                                  ).merge(Theme.of(context).textTheme.headline5),
+                                ),
+                                IconButton(
+                                  onPressed: () => Clipboard.setData(ClipboardData(text: speaker.name)).then((_) => ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text('Speaker name copied to clipboard'))
+                                  )),
+                                  icon: Icon(Icons.copy),
+                                  iconSize: 18,
+                                  color: Theme.of(context).colorScheme.secondary
+                                ),
+                            ]),
                             SelectableText(
                               speaker.title!,
                               style: TextStyle(

--- a/frontend/lib/routes/speaker/banner/SpeakerBanner.dart
+++ b/frontend/lib/routes/speaker/banner/SpeakerBanner.dart
@@ -126,15 +126,18 @@ class SpeakerBanner extends StatelessWidget {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
+                            SelectableText(
                               speaker.name,
-                              style: Theme.of(context).textTheme.headline5,
-                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                overflow: TextOverflow.ellipsis,
+                              ).merge(Theme.of(context).textTheme.headline5),
                             ),
-                            Text(speaker.title!,
-                                style: Theme.of(context).textTheme.subtitle1,
-                                softWrap: false,
-                                overflow: TextOverflow.ellipsis),
+                            SelectableText(
+                              speaker.title!,
+                              style: TextStyle(
+                                overflow: TextOverflow.ellipsis,
+                              ).merge(Theme.of(context).textTheme.subtitle1),
+                            ),
                             if (isLatestEvent && hasParticipation)
                               SpeakerStatusDropdownButton(
                                 speakerStatus: speakerStatus,


### PR DESCRIPTION
Allow text selection of banners titles and add copy to clipboard button of speaker and company name.

Closes #385 