### PR TITLE
Disallow members to edit a company/speaker status unless they are doing it in the current event

### DIFF
--- a/frontend/lib/components/ListViewCard.dart
+++ b/frontend/lib/components/ListViewCard.dart
@@ -1,3 +1,5 @@
+import 'dart:html';
+
 import 'package:flutter/material.dart';
 import 'package:frontend/routes/company/CompanyScreen.dart';
 import 'package:frontend/routes/company/CompanyTableNotifier.dart';
@@ -15,6 +17,7 @@ import 'package:collection/collection.dart';
 import 'package:frontend/services/companyService.dart';
 import 'package:frontend/services/speakerService.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter/foundation.dart';
 
 class ListViewCard extends StatefulWidget {
   final Member? member;
@@ -33,9 +36,11 @@ class ListViewCard extends StatefulWidget {
   late final bool? _editable;
   late Widget _screen;
   final Future<void> Function(int, BuildContext)? onChangeParticipationStatus;
+  int? latestEvent;
 
   ListViewCard(
       {Key? key,
+      this.latestEvent,
       required this.small,
       this.member,
       this.company,
@@ -47,9 +52,9 @@ class ListViewCard extends StatefulWidget {
       int? event = App.localStorage.getInt("event");
       if (event != null) {
         if (company != null) {
-          _initCompany(event);
+          _initCompany(event, this.latestEvent);
         } else if (speaker != null) {
-          _initSpeaker(event);
+          _initSpeaker(event, this.latestEvent);
         } else if (member != null) {
           _initMember(event);
         }
@@ -67,13 +72,13 @@ class ListViewCard extends StatefulWidget {
     _editable = false;
   }
 
-  void _initCompany(int event) {
+  void _initCompany(int event, int? latestEvent) {
     _tag = company!.id + event.toString();
     _screen = CompanyScreen(company: company!);
     CompanyParticipation? participation = company!.participations!
         .firstWhereOrNull((element) => element.event == event);
     if (participation != null) {
-      _editable = participation.event == event;
+      _editable = latestEvent == event;
     } else {
       _editable = false;
     }
@@ -89,7 +94,7 @@ class ListViewCard extends StatefulWidget {
     _lastParticipation = company!.lastParticipation;
   }
 
-  void _initSpeaker(int event) {
+  void _initSpeaker(int event, int? latestEvent) {
     _tag = speaker!.id + event.toString();
     _screen = SpeakerScreen(speaker: speaker!);
     SpeakerParticipation? participation =
@@ -97,7 +102,7 @@ class ListViewCard extends StatefulWidget {
       (element) => element.event == event,
     );
     if (participation != null) {
-      _editable = participation.event == event;
+      _editable = latestEvent == event;
     } else {
       _editable = false;
     }

--- a/frontend/lib/routes/company/CompanyListWidget.dart
+++ b/frontend/lib/routes/company/CompanyListWidget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/components/ListViewCard.dart';
 import 'package:frontend/components/appbar.dart';
+import 'package:frontend/components/eventNotifier.dart';
 import 'package:frontend/main.dart';
 import 'package:frontend/models/company.dart';
 import 'package:frontend/routes/company/CompanyTableNotifier.dart';
@@ -100,6 +101,7 @@ class _CompanyListWidgetState extends State<CompanyListWidget> {
 
   @override
   Widget build(BuildContext context) {
+    int latestEvent = Provider.of<EventNotifier>(context).latest.id;
     return FutureBuilder<List<Company>>(
         future: companies,
         builder: (context, snapshot) {
@@ -155,6 +157,7 @@ class _CompanyListWidgetState extends State<CompanyListWidget> {
                           itemCount: comp.length,
                           itemBuilder: (BuildContext context, int index) {
                             return ListViewCard(
+                              latestEvent: latestEvent,
                               small: isSmall,
                               company: comp[index],
                               participationsInfo: true,

--- a/frontend/lib/routes/company/CompanyTable.dart
+++ b/frontend/lib/routes/company/CompanyTable.dart
@@ -206,6 +206,7 @@ class MemberCompanyRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     int event = Provider.of<EventNotifier>(context).event.id;
+    int latestEvent = Provider.of<EventNotifier>(context).latest.id;
 
     List<Company> companies = Provider.of<CompanyTableNotifier>(context)
         .getByMember(member.id, event, filter);
@@ -251,6 +252,7 @@ class MemberCompanyRow extends StatelessWidget {
                           scrollDirection: Axis.horizontal,
                           children: companies
                               .map((e) => ListViewCard(
+                                  latestEvent: latestEvent,
                                   small: true,
                                   company: e,
                                   onChangeParticipationStatus:
@@ -276,6 +278,7 @@ class MemberCompanyRow extends StatelessWidget {
                                 crossAxisAlignment: WrapCrossAlignment.start,
                                 children: companies
                                     .map((e) => ListViewCard(
+                                          latestEvent: latestEvent,
                                           small: false,
                                           company: e,
                                           onChangeParticipationStatus:

--- a/frontend/lib/routes/speaker/SpeakerListWidget.dart
+++ b/frontend/lib/routes/speaker/SpeakerListWidget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/components/ListViewCard.dart';
 import 'package:frontend/components/appbar.dart';
+import 'package:frontend/components/eventNotifier.dart';
 import 'package:frontend/main.dart';
 import 'package:frontend/models/speaker.dart';
 import 'package:frontend/routes/speaker/speakerNotifier.dart';
@@ -99,6 +100,7 @@ class _SpeakerListWidgetState extends State<SpeakerListWidget> {
 
   @override
   Widget build(BuildContext context) {
+    int latestEvent = Provider.of<EventNotifier>(context).latest.id;
     return FutureBuilder<List<Speaker>>(
         future: speakers,
         builder: (context, snapshot) {
@@ -154,6 +156,7 @@ class _SpeakerListWidgetState extends State<SpeakerListWidget> {
                           itemCount: speak.length,
                           itemBuilder: (BuildContext context, int index) {
                             return ListViewCard(
+                                latestEvent: latestEvent,
                                 small: isSmall,
                                 speaker: speak[index],
                                 participationsInfo: true,

--- a/frontend/lib/routes/speaker/SpeakerTable.dart
+++ b/frontend/lib/routes/speaker/SpeakerTable.dart
@@ -217,6 +217,7 @@ class MemberSpeakerRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     int event = Provider.of<EventNotifier>(context).event.id;
+    int latestEvent = Provider.of<EventNotifier>(context).latest.id;
 
     List<Speaker> speakers = Provider.of<SpeakerTableNotifier>(context)
         .getByMember(member.id, event, filter);
@@ -262,6 +263,7 @@ class MemberSpeakerRow extends StatelessWidget {
                           scrollDirection: Axis.horizontal,
                           children: speakers
                               .map((e) => ListViewCard(
+                                    latestEvent: latestEvent,
                                     small: true,
                                     speaker: e,
                                     onChangeParticipationStatus:
@@ -288,6 +290,7 @@ class MemberSpeakerRow extends StatelessWidget {
                                 crossAxisAlignment: WrapCrossAlignment.start,
                                 children: speakers
                                     .map((e) => ListViewCard(
+                                          latestEvent: latestEvent,
                                           small: false,
                                           speaker: e,
                                           onChangeParticipationStatus:


### PR DESCRIPTION
Both in speakers/companies by member and all speakers/companies status button is editable only for the latest event