### PR TITLE
Update 1.1.1

### DIFF
--- a/frontend/lib/routes/members_teams/teams/TeamScreen.dart
+++ b/frontend/lib/routes/members_teams/teams/TeamScreen.dart
@@ -507,7 +507,7 @@ class _DisplayMeetingState extends State<DisplayMeeting>
     List<Future<Meeting?>> _futureMeetings =
         widget.meetingsIds!.map((m) => _meetingService.getMeeting(m)).toList();
 
-    membersPage = false;
+    // membersPage = false;
 
     return Scaffold(
       body: (widget.meetingsIds == null)


### PR DESCRIPTION
frontend: temporary fix in TeamScreen

Allows admins to add new members to deck. Temporary fix that should be looked into in the future